### PR TITLE
Issue-2: Added additional connection options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .pytest_cache/
 .vscode/
+__pycache__/


### PR DESCRIPTION
Added the following menu options:

* Connect to the fastest p2p, tor, or secure core server
* Connect to the fastest server for a selected country; the country list is dynamically populated when `protonvpn-applet` is started
* Connect to a random server
* Reconnect

`Connect` now just connects to the fastest server.

See https://github.com/seadanda/protonvpn-applet/issues/2 for details.